### PR TITLE
Fix role type error in Strong mode + Dart2

### DIFF
--- a/lib/src/objects/role.dart
+++ b/lib/src/objects/role.dart
@@ -13,7 +13,7 @@ class Role extends Resource {
   /// 
   /// Typically, for [preset], you will want to use RolePermission.values. 
   static List<RolePermission> permissionFromRaw(int raw, {List<RolePermission> preset = RolePermission.values}) =>
-    preset.where((p) => raw & _permissionMap[p] != 0);
+    preset.where((p) => raw & _permissionMap[p] != 0).toList();
   
   static final Map<RolePermission, int> _permissionMap = {
     RolePermission.createInstantInvite: 1 << 0,


### PR DESCRIPTION
This fixes the following error:

```
Unhandled exception:
type 'WhereIterable<RolePermission>' is not a subtype of type 'List<RolePermission>' of 'function result' where
  WhereIterable is from dart:_internal
  RolePermission is from package:dartsicord/src/enums.dart
  List is from dart:core
  RolePermission is from package:dartsicord/src/enums.dart
```

Issue is caused by Dart Strong mode enforcing the List requirement.