### PR TITLE
Update to work with Dart 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Files and directories created by pub
 .packages
 .pub/
+.dart_tool/
+.vs_code/
 build/
 example-private/
 pubspec.lock

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: false
 #   exclude:
 #     - path/to/excluded/files/**
 
@@ -27,7 +28,7 @@ linter:
 
     # Style Rules
     - always_declare_return_types
-    - avoid_as
+    # - avoid_as
     - avoid_classes_with_only_static_members
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null

--- a/lib/dartsicord.dart
+++ b/lib/dartsicord.dart
@@ -1,17 +1,5 @@
 library dartsicord;
 
-/*export "src/client.dart";
-export "src/enums.dart";
-export "src/exception.dart";
-
-export "src/objects/channel.dart";
-export "src/objects/embed.dart";
-export "src/objects/emoji.dart";
-export "src/objects/game.dart";
-export "src/objects/guild.dart";
-export "src/objects/message.dart";
-export "src/objects/user.dart";*/
-
 import "dart:async";
 import "dart:convert";
 import "dart:io";

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 /*
 import "dart:async";
@@ -86,60 +86,79 @@ class DiscordClient extends _EventExhibitor {
 
   /// Fired when the client receives the `READY` payload.
   _EventStream<ReadyEvent> onReady;
+
   /// Fired when the client's user updates.
   _EventStream<UserUpdateEvent> onUserUpdate;
 
   /// Fired when the client sees a guild created. Not fired before [ready] is reached.
   _EventStream<GuildCreateEvent> onGuildCreate;
+
   /// Fired when the client sees a guild update.
   _EventStream<GuildUpdateEvent> onGuildUpdate;
+
   /// Fired when the client is removed from a guild.
   _EventStream<GuildRemoveEvent> onGuildRemove;
+
   /// Fired when the client sees a guild become unavailable.
   _EventStream<GuildUnavailableEvent> onGuildUnavailable;
 
   /// Fired when the client sees a user banned.
   _EventStream<MemberBannedEvent> onMemberBanned;
+
   /// Fired when the client sees a user unbanned.
   _EventStream<MemberUnbannedEvent> onMemberUnbanned;
+
   /// Fired when the client sees a guild update its emojis.
   _EventStream<GuildEmojisUpdateEvent> onGuildEmojisUpdated;
+
   /// Fired when the client sees a guild update its integrations.
   _EventStream<GuildIntegrationsUpdateEvent> onGuildIntegrationsUpdated;
+
   /// Fired when the client sees a member updated on its guild.
   _EventStream<MemberUpdatedEvent> onMemberUpdated;
+
   /// Fired when the client sees a user join a guild.
   _EventStream<MemberAddedEvent> onMemberAdded;
+
   /// Fired when the client sees a user get removed from a guild. (left, kicked, banned, etc.)
   _EventStream<MemberRemovedEvent> onMemberRemoved;
 
   /// Fired when the client sees a role created in a guild.
   _EventStream<RoleCreatedEvent> onRoleCreated;
+
   /// Fired when the client sees a role updated in a guild.
   _EventStream<RoleUpdatedEvent> onRoleUpdated;
+
   /// Fired when the client sees a role deleted in a guild.
   _EventStream<RoleDeletedEvent> onRoleDeleted;
 
   /// Fired when the client sees a message created.
   _EventStream<MessageCreateEvent> onMessage;
+
   /// Fired when the client sees a message delete.
   _EventStream<MessageDeleteEvent> onMessageDelete;
+
   /// Fired when the client sees messages bulk-deleted.
   _EventStream<MessageDeleteBulkEvent> onMessageBulkDelete;
 
   /// Fired when the client sees a reaction created on a message.
   _EventStream<ReactionAddEvent> onReactionAdd;
+
   /// Fired when the client sees a reaction removed from a message.
   _EventStream<ReactionRemoveEvent> onReactionRemove;
+
   /// Fired when the client sees all reactions removed from a message.
   _EventStream<ReactionRemoveAllEvent> onReactionRemoveAll;
 
   /// Fired when the client sees a channel created.
   _EventStream<ChannelCreateEvent> onChannelCreate;
+
   /// Fired when the client sees a channel updated.
   _EventStream<ChannelUpdateEvent> onChannelUpdate;
+
   /// Fired when the client sees a channel deleted.
   _EventStream<ChannelDeleteEvent> onChannelDelete;
+
   /// Fired when the client sees a channel update its pins.
   _EventStream<ChannelPinsUpdateEvent> onChannelPinsUpdate;
 
@@ -154,9 +173,9 @@ class DiscordClient extends _EventExhibitor {
 
   // Internal methods
 
-  Future _getGateway() async {
+  Future<String> _getGateway() async {
     final response = await (api + "gateway").get();
-    return json.decode(await response.readAsString())["url"];
+    return json.decode(response.body)["url"] as String;
   }
 
   void _sendHeartbeat(Timer timer) {
@@ -208,53 +227,57 @@ class DiscordClient extends _EventExhibitor {
     return "data:image/$headerType;base64,$encoded";
   }
 
-
   // External methods
 
   /// Modify the client's user. If you pass [avatar], you must pass [avatarFileType] or it will default to `jpg`.
-  Future modify({String username, File avatar, String avatarFileType = "jpg"}) async {
+  Future modify(
+      {String username, File avatar, String avatarFileType = "jpg"}) async {
     final query = {};
 
     if (username != null) query["username"] = username;
-    if (avatar != null) query["avatar"] = await _avatarData(avatar, avatarFileType);
+    if (avatar != null)
+      query["avatar"] = await _avatarData(avatar, avatarFileType);
 
     final response = await (api + "users" + "@me").patch(query);
-    return User._fromMap(json.decode(await response.readAsString()), this);
+    return User._fromMap(
+        json.decode(response.body) as Map<String, dynamic>, this);
   }
 
   /// Get a guild from the client's cache.
-  Guild getGuild(dynamic id) => 
-    guilds.firstWhere((g) =>
-      g.id.toString() == id.toString()
-    );
-  
+  Guild getGuild(dynamic id) =>
+      guilds.firstWhere((g) => g.id.toString() == id.toString());
+
   /// Get a channel given its [id].
-  Future<Channel> getChannel(dynamic id) async {
-    if (!guilds.any((g) => g.channels.any((c) => c.id == id))) // Check if this channel is already cached.
-      return guilds.firstWhere((c) => c.id == id).channels.firstWhere((c) => c.id == id);
+  Future<T> getChannel<T extends Channel>(dynamic id) async {
+    if (!guilds.any((g) => g.channels
+        .any((c) => c.id == id))) // Check if this channel is already cached.
+      return guilds
+          .firstWhere((c) => c.id == id)
+          .channels
+          .firstWhere((c) => c.id == id) as T;
 
     final response = await (api + "channels" + id).get();
-    return Channel._fromMap(json.decode(await response.readAsString()), this);
+    return Channel._fromMap<T>(
+        json.decode(response.body) as Map<String, dynamic>, this);
   }
 
   /// Get a text channel given its [id].
-  Future<TextChannel> getTextChannel(dynamic id) =>
-    getChannel(id);
-
-
+  Future<TextChannel> getTextChannel(dynamic id) async =>
+      await getChannel(id) as TextChannel;
 
   // External method references
 
   /// Sends a message to a text channel. See [TextChannel.sendMessage]
-  Future<Message> sendMessage(String content, TextChannel channel, {Embed embed}) =>
-    channel.sendMessage(content, embed: embed);
+  Future<Message> sendMessage(String content, TextChannel channel,
+          {Embed embed}) =>
+      channel.sendMessage(content, embed: embed);
 
   /// Creates a direct message channel with the given [recipient].
   Future<TextChannel> createDirectMessage(User recipient) =>
-    recipient.createDirectMessage();
-  
+      recipient.createDirectMessage();
+
   /// Updates the client's status using a [StatusType] status enum.
-  /// 
+  ///
   /// Optionally, you can include a self-made [Game] object and whether
   /// or not the client should be considered AFK.
   void updateStatus(StatusType status, {Game game, bool afk = false}) {
@@ -264,18 +287,11 @@ class DiscordClient extends _EventExhibitor {
       "game": game?._toMap(),
       "since": null
     };
-    final packet = new Packet(
-      opcode: 3,
-      data: query,
-      seq: _lastSeq,
+    final packet =
+        new Packet(opcode: 3, data: query, seq: _lastSeq, client: this);
 
-      client: this
-    );
-    
     _socket.add(packet.toString());
   }
-
-
 
   // Constructor
 
@@ -291,7 +307,7 @@ class DiscordClient extends _EventExhibitor {
   }
 
   void _sendIdentify() {
-		Packet packet = new Packet(opcode: 2, seq: _lastSeq, data: {
+    final packet = new Packet(opcode: 2, seq: _lastSeq, data: {
       "token": token,
       "properties": {
         "\$os": "windows",
@@ -302,13 +318,13 @@ class DiscordClient extends _EventExhibitor {
       "compress": false,
       "large_threshold": 250
     });
-		if (shard != null)
-			packet.data["shard"] = [shard, shardCount];
+    if (shard != null) packet.data["shard"] = [shard, shardCount];
 
-		_socket.add(packet.toString());
+    _socket.add(packet.toString());
   }
 
-  Future<Null> _establishConnection(String token, {TokenType tokenType = TokenType.bot, bool reconnecting = false}) async {
+  Future<Null> _establishConnection(String token,
+      {TokenType tokenType = TokenType.bot, bool reconnecting = false}) async {
     _closed = false;
 
     this.token = token;
@@ -318,26 +334,26 @@ class DiscordClient extends _EventExhibitor {
     _socket = await WebSocket.connect(gateway + "?v=6&encoding=json");
 
     _socket.listen((payloadRaw) async {
-      final payload = json.decode(payloadRaw);
+      final payload = json.decode(payloadRaw as String);
       final packet = new Packet(
-        data: payload["d"],
-        event: payload["t"],
-        opcode: payload["op"],
-        seq: payload["s"],
-        client: this);
+          data: payload["d"],
+          event: payload["t"] as String,
+          opcode: payload["op"] as int,
+          seq: payload["s"] as int,
+          client: this);
 
-      if (packet.seq != null)
-        _lastSeq = packet.seq;
+      if (packet.seq != null) _lastSeq = packet.seq;
 
       switch (packet.opcode) {
         case 0: // Dispatch
           final event = payload["t"];
           if (ready) {
-            if (_websocketEvents.containsKey(event)) await _websocketEvents[event](packet);
+            if (_websocketEvents.containsKey(event))
+              await _websocketEvents[event](packet);
           } else {
             if (event == "READY")
               await ReadyEvent.construct(packet);
-            else if(event == "GUILD_CREATE")
+            else if (event == "GUILD_CREATE")
               await GuildCreateEvent.construct(packet);
           }
 
@@ -359,7 +375,10 @@ class DiscordClient extends _EventExhibitor {
           _sendIdentify();
           break;
         case 10: // Hello
-          _heartbeat = new Timer.periodic(new Duration(milliseconds: packet.data["heartbeat_interval"]), _sendHeartbeat);
+          _heartbeat = new Timer.periodic(
+              new Duration(
+                  milliseconds: packet.data["heartbeat_interval"] as int),
+              _sendHeartbeat);
           if (reconnecting) {
             _socket.add(new Packet(opcode: 6, seq: _lastSeq, data: {
               "token": token,
@@ -390,9 +409,9 @@ class DiscordClient extends _EventExhibitor {
   }
 
   Future<Null> _reconnect() =>
-    _establishConnection(token, tokenType: tokenType, reconnecting: true);
-  
+      _establishConnection(token, tokenType: tokenType, reconnecting: true);
+
   /// Connects to Discord's API.
   Future<Null> connect(String token, {TokenType tokenType = TokenType.bot}) =>
-    _establishConnection(token, tokenType: tokenType, reconnecting: false);
+      _establishConnection(token, tokenType: tokenType, reconnecting: false);
 }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -1,49 +1,22 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 /// The type of the channel.
-enum ChannelType {
-  guildText,
-  dm,
-  guildVoice,
-  groupDm,
-  guildCategory
-}
+enum ChannelType { guildText, dm, guildVoice, groupDm, guildCategory }
 
 /// The token type of the authorized bot.
-enum TokenType {
-  bot,
-  user
-}
+enum TokenType { bot, user }
 
 /// The user's status.
-enum StatusType {
-  online,
-  doNotDisturb,
-  away,
-  invisible,
-  offline
-}
+enum StatusType { online, doNotDisturb, away, invisible, offline }
 
 /// Directs the library how to download messages.
-enum MessageDownloadType {
-  before,
-  after,
-  around
-}
+enum MessageDownloadType { before, after, around }
 
 /// The activity the user is engaged in.
-enum ActivityType {
-  game,
-  stream,
-  listen,
-  watch
-}
+enum ActivityType { game, stream, listen, watch }
 
 /// The type of permission overwrite for the channel.
-enum OverwriteType {
-  role,
-  member
-}
+enum OverwriteType { role, member }
 
 /// The role permissions.
 enum RolePermission {

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 class _EventStream<T> extends Stream<T> {
   StreamController<T> _controller;
@@ -9,8 +9,10 @@ class _EventStream<T> extends Stream<T> {
     _stream = _controller.stream;
   }
 
-  StreamSubscription<T> listen(void onData(T event), {Function onError, void onDone(), bool cancelOnError}) => 
-      _stream.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  StreamSubscription<T> listen(void onData(T event),
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      _stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   void add(T event) => _controller.add(event);
   Future close() => _controller.close();
@@ -19,14 +21,15 @@ class _EventStream<T> extends Stream<T> {
 abstract class _EventExhibitor {
   final List<_EventStream> _events = [];
 
-  _EventStream createEvent() {
-    final event = new _EventStream();
+  _EventStream<T> createEvent<T>() {
+    final event = new _EventStream<T>();
     _events.add(event);
 
     return event;
   }
 
-  Future<List> destroyEvents() => Future.wait(_events.map((event) => event.close()));
+  Future<List> destroyEvents() =>
+      Future.wait(_events.map((event) => event.close()));
 }
 
 typedef Future<Null> WebSocketEventConstructor(Packet packet);
@@ -37,37 +40,48 @@ class ReadyEvent {
   static Future<Null> construct(Packet packet) async {
     packet.client
       ..ready = true
-      ..sessionId = packet.data["session_id"]
-      ..user = await User._fromMap(packet.data["user"], packet.client);
+      ..sessionId = packet.data["session_id"] as String
+      ..user = await User._fromMap(
+          packet.data["user"] as Map<String, dynamic>, packet.client);
 
     final event = new ReadyEvent();
     packet.client.onReady.add(event);
   }
 }
+
 class UserUpdateEvent {
   UserUpdateEvent();
 
   static Future<Null> construct(Packet packet) async {
-    packet.client.user = await User._fromMap(packet.data, packet.client);
+    final Map<String, dynamic> data = packet.data;
+    packet.client.user = await User._fromMap(data, packet.client);
 
     final event = new UserUpdateEvent();
     packet.client.onUserUpdate.add(event);
   }
 }
+
 class PresenceUpdateEvent {
   /// The user in which presence has been updated.
   User user;
+
   /// The [Game] object representing the game the user is playing, if any.
   Game game;
+
   /// The status of the user, based on the [StatusType] enum.
   StatusType status;
 
   PresenceUpdateEvent(this.user, this.status, {this.game});
 
   static Future<Null> construct(Packet packet) async {
-    final user = await User._fromMap(packet.data["user"], packet.client);
-    final game = packet.data["game"] != null ? await Game._fromMap(packet.data["game"], packet.client) : null;
-    final status = Game.statuses[packet.data["status"]];
+    final Map<String, dynamic> data = packet.data;
+    final user = await User._fromMap(
+        data["user"] as Map<String, dynamic>, packet.client);
+    final game = data["game"] != null
+        ? await Game._fromMap(
+            data["game"] as Map<String, dynamic>, packet.client)
+        : null;
+    final status = Game.statuses[data["status"]];
 
     final event = new PresenceUpdateEvent(user, status, game: game);
     packet.client.onPresenceUpdate.add(event);

--- a/lib/src/events/channel.dart
+++ b/lib/src/events/channel.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 class ChannelCreateEvent {
   /// The created channel.
@@ -6,28 +6,30 @@ class ChannelCreateEvent {
   ChannelCreateEvent(this.channel);
 
   static Future<Null> construct(Packet packet) async {
+    final Map<String, dynamic> data = packet.data;
+    final channel = await Channel._fromMap(data, packet.client);
 
-    final channel = await Channel._fromMap(packet.data, packet.client);
-
-    if (channel.guild != null && !channel.guild.channels.any((c) => c.id == channel.id))
+    if (channel.guild != null &&
+        !channel.guild.channels.any((c) => c.id == channel.id))
       channel.guild.channels.add(channel);
-    
+
     final event = new ChannelCreateEvent(channel);
     packet.client.onChannelCreate.add(event);
-
   }
 }
+
 class ChannelUpdateEvent {
   /// The updated channel.
   Channel channel;
   ChannelUpdateEvent(this.channel);
 
   static Future<Null> construct(Packet packet) async {
-    var channel = await Channel._fromMap(packet.data, packet.client);
+    final Map<String, dynamic> data = packet.data;
+    var channel = await Channel._fromMap(data, packet.client);
     if (channel.guild != null) {
-      final existing = channel.guild.channels.firstWhere((c) => c.id == channel.id)
-        ..name = channel.name;
-      
+      final existing = channel.guild.channels
+          .firstWhere((c) => c.id == channel.id)
+            ..name = channel.name;
 
       if (existing is TextChannel && channel is TextChannel)
         existing
@@ -40,70 +42,85 @@ class ChannelUpdateEvent {
 
       channel = existing;
     }
-    
+
     final event = new ChannelUpdateEvent(channel);
     packet.client.onChannelUpdate.add(event);
   }
 }
+
 class ChannelDeleteEvent {
   /// The deleted channel. Methods will not work on this instance.
   Channel channel;
   ChannelDeleteEvent(this.channel);
 
   static Future<Null> construct(Packet packet) async {
-    final channel = await Channel._fromMap(packet.data, packet.client);
+    final Map<String, dynamic> data = packet.data;
+    final channel = await Channel._fromMap(data, packet.client);
     if (channel.guild != null)
       channel.guild.channels.removeWhere((c) => c.id == channel.id);
-    
+
     final event = new ChannelUpdateEvent(channel);
     packet.client.onChannelUpdate.add(event);
   }
 }
+
 class ChannelPinsUpdateEvent {
   /// The channel in which pins have been updated.
   TextChannel channel;
+
   /// A [DateTime] of the most recently pinned pin.
   DateTime lastPinAt;
 
   ChannelPinsUpdateEvent(this.channel, {this.lastPinAt});
 
   static Future<Null> construct(Packet packet) async {
-    final channel = await packet.client.getTextChannel(packet.data["channel_id"]);
-    final lastPinAt = packet.data["last_pin_timestamp"] != null ? DateTime.parse(packet.data["last_pin_timestamp"]) : null;
+    final channel =
+        await packet.client.getTextChannel(packet.data["channel_id"]);
+    final lastPinAt = packet.data["last_pin_timestamp"] != null
+        ? DateTime.parse(packet.data["last_pin_timestamp"] as String)
+        : null;
 
     final event = new ChannelPinsUpdateEvent(channel, lastPinAt: lastPinAt);
     packet.client.onChannelPinsUpdate.add(event);
   }
 }
+
 class WebhooksUpdateEvent {
   /// The channel in which webhooks have been updated.
   TextChannel channel;
+
   /// The guild that contains the channel that webhooks have been updated.
   Guild guild;
 
   WebhooksUpdateEvent(this.channel, {this.guild});
 
   static Future<Null> construct(Packet packet) async {
-    final channel = await packet.client.getTextChannel(packet.data["channel_id"]);
-    final _Route = packet.client.api + "channels" + channel.id + "webhooks";
-    final response = await _Route.get();
-    final webhooks = json.decode(await response.readAsString());
-    channel.webhooks = webhooks.map((w) async => await Webhook._fromMap(w, packet.client));
+    final channel =
+        await packet.client.getTextChannel(packet.data["channel_id"]);
+    final route = packet.client.api + "channels" + channel.id + "webhooks";
+    final response = await route.get();
+    final webhooks =
+        (json.decode(response.body) as List).cast<Map<String, dynamic>>();
+    channel.webhooks = await Future.wait(
+        webhooks.map((w) => Webhook._fromMap(w, packet.client)));
 
     final event = new WebhooksUpdateEvent(channel, guild: channel.guild);
     packet.client.onWebhooksUpdate.add(event);
   }
 }
+
 class TypingStartEvent {
   /// The channel in which someone is typing.
   TextChannel channel;
+
   /// A [Snowflake] object representing the user that was typing. If you need this object, see `User.get`.
   Snowflake userId;
 
   TypingStartEvent(this.channel, this.userId);
 
   static Future<Null> construct(Packet packet) async {
-    final channel = await packet.client.getTextChannel(packet.data["channel_id"]);
+    final channel =
+        await packet.client.getTextChannel(packet.data["channel_id"]);
     final userId = new Snowflake(packet.data["user_id"]);
 
     final event = new TypingStartEvent(channel, userId);

--- a/lib/src/events/message.dart
+++ b/lib/src/events/message.dart
@@ -1,63 +1,74 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 class MessageCreateEvent {
   /// The channel the message was created in.
   Channel channel;
+
   /// The guild of the channel that the message was created in. This may be null as this may be a non-guild message.
   Guild guild;
+
   /// The user that created this message. May be null due to webhooks.
   User author;
+
   /// The message that was created.
   Message message;
 
   MessageCreateEvent(this.message, {this.author, this.guild, this.channel});
 
   static Future<Null> construct(Packet packet) async {
-    final message = await Message._fromMap(packet.data, packet.client);
+    final Map<String, dynamic> data = packet.data;
+    final message = await Message._fromMap(data, packet.client);
     final event = new MessageCreateEvent(message,
-      author: message.author,
-      channel: message.channel,
-      guild: message.guild);
+        author: message.author, channel: message.channel, guild: message.guild);
     packet.client.onMessage.add(event);
   }
 }
+
 class MessageDeleteEvent {
   /// The [TextChannel] this message was deleted in.
   TextChannel channel;
+
   /// A snowflake ID of the message that was deleted.
   Snowflake messageId;
 
   MessageDeleteEvent(this.channel, this.messageId);
 
   static Future<Null> construct(Packet packet) async {
+    final Map<String, dynamic> data = packet.data;
     final event = new MessageDeleteEvent(
-      await packet.client.getChannel(packet.data["channel_id"]),
-      new Snowflake(packet.data["id"])
-    );
+        await packet.client.getChannel(data["channel_id"]) as TextChannel,
+        new Snowflake(data["id"]));
     packet.client.onMessageDelete.add(event);
   }
 }
+
 class MessageDeleteBulkEvent {
   /// The [TextChannel] these messages were deleted in.
   TextChannel channel;
+
   /// A list of [Snowflake] objects representing the deleted messages.
   List<Snowflake> messages;
 
   MessageDeleteBulkEvent(this.messages, this.channel);
 
   static Future<Null> construct(Packet packet) async {
-    final channel = await packet.client.getTextChannel(packet.data["channel_id"]);
-    final ids = packet.data["ids"].map((i) => new Snowflake(i));
+    final channel =
+        await packet.client.getTextChannel(packet.data["channel_id"]);
+    final ids =
+        (packet.data["ids"] as List).map((i) => new Snowflake(i)).toList();
 
     final event = new MessageDeleteBulkEvent(ids, channel);
     packet.client.onMessageBulkDelete.add(event);
   }
 }
+
 class ReactionAddEvent {
   /// The user id of the reactor. You will need to fetch this user through client methods if absolutely necessary.
   Snowflake userId;
+
   /// The channel id of the reactor. You will need to use `DiscordClient.getChannel` if necessary.
   Snowflake channelId;
+
   /// The message id of the reactor. You will need to use `DiscordClient.getChannel` and `Channel.getMessage` if necessary.
   Snowflake messageId;
 
@@ -67,39 +78,49 @@ class ReactionAddEvent {
   ReactionAddEvent(this.emoji, {this.userId, this.channelId, this.messageId});
 
   static Future<Null> construct(Packet packet) async {
-    final event = new ReactionAddEvent(await Emoji._fromMap(packet.data["emoji"], packet.client),
-      userId: new Snowflake(packet.data["user_id"]),
-      channelId: new Snowflake(packet.data["channel_id"]),
-      messageId: new Snowflake(packet.data["message_id"])
-    );
+    final Map<String, dynamic> data = packet.data;
+    final event = new ReactionAddEvent(
+        await Emoji._fromMap(
+            data["emoji"] as Map<String, dynamic>, packet.client),
+        userId: new Snowflake(data["user_id"]),
+        channelId: new Snowflake(data["channel_id"]),
+        messageId: new Snowflake(data["message_id"]));
     packet.client.onReactionAdd.add(event);
   }
 }
+
 class ReactionRemoveEvent {
   /// The user id of the reactor. You will need to fetch this user through client methods if absolutely necessary.
   Snowflake userId;
+
   /// The channel id of the reaction. You will need to use `DiscordClient.getChannel` if necessary.
   Snowflake channelId;
+
   /// The message id of the reaction. You will need to use `DiscordClient.getChannel` and `Channel.getMessage` if necessary.
   Snowflake messageId;
 
   /// A partial emoji object representing the emoji that was used. Look for parameters `id` and `name`.
   Emoji emoji;
 
-  ReactionRemoveEvent(this.emoji, {this.userId, this.channelId, this.messageId});
+  ReactionRemoveEvent(this.emoji,
+      {this.userId, this.channelId, this.messageId});
 
   static Future<Null> construct(Packet packet) async {
-    final event = new ReactionRemoveEvent(await Emoji._fromMap(packet.data["emoji"], packet.client),
-      userId: new Snowflake(packet.data["user_id"]),
-      channelId: new Snowflake(packet.data["channel_id"]),
-      messageId: new Snowflake(packet.data["message_id"])
-    );
+    final Map<String, dynamic> data = packet.data;
+    final event = new ReactionRemoveEvent(
+        await Emoji._fromMap(
+            data["emoji"] as Map<String, dynamic>, packet.client),
+        userId: new Snowflake(data["user_id"]),
+        channelId: new Snowflake(data["channel_id"]),
+        messageId: new Snowflake(data["message_id"]));
     packet.client.onReactionRemove.add(event);
   }
 }
+
 class ReactionRemoveAllEvent {
   /// The channel id of the message with reactions removed. You will need to use `DiscordClient.getChannel` if necessary.
   Snowflake channelId;
+
   /// The message id of the message with reactions removed. You will need to use `DiscordClient.getChannel` and `Channel.getMessage` if necessary.
   Snowflake messageId;
 
@@ -107,9 +128,8 @@ class ReactionRemoveAllEvent {
 
   static Future<Null> construct(Packet packet) async {
     final event = new ReactionRemoveAllEvent(
-      channelId: new Snowflake(packet.data["channel_id"]),
-      messageId: new Snowflake(packet.data["message_id"])
-    );
+        channelId: new Snowflake(packet.data["channel_id"]),
+        messageId: new Snowflake(packet.data["message_id"]));
     packet.client.onReactionRemoveAll.add(event);
   }
 }

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 class NotAuthorException implements Exception {
   NotAuthorException() : super();

--- a/lib/src/networking.dart
+++ b/lib/src/networking.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 class _Route {
   String url = "https://discordapp.com/api";
@@ -7,13 +7,14 @@ class _Route {
   _Route({this.client});
 
   _Route operator +(dynamic other) =>
-    new _Route(client: client)..url = url + "/" + other.toString();
+      new _Route(client: client)..url = url + "/" + other.toString();
 
-  Map<String, String> authHeader({Map<String, String> header}) =>
-		({
-			"Authorization": (client.tokenType == TokenType.bot ? "Bot " : "") + "${client.token}",
-			"Content-Type": "application/json"
-		})..addAll(header ?? {});
+  Map<String, String> authHeader({Map<String, String> header}) => ({
+        "Authorization": (client.tokenType == TokenType.bot ? "Bot " : "") +
+            "${client.token}",
+        "Content-Type": "application/json"
+      })
+        ..addAll(header ?? {});
 
   void handleStatusCode(http.Response response) {
     switch (response.statusCode) {
@@ -49,23 +50,33 @@ class _Route {
     handleStatusCode(response);
     return response;
   }
+
   Future<http.Response> delete({Map<String, String> headers}) async {
-    final response = await http.delete(url, headers: authHeader(header: headers));
+    final response =
+        await http.delete(url, headers: authHeader(header: headers));
     handleStatusCode(response);
     return response;
   }
-  Future<http.Response> post(dynamic body, {Map<String, String> headers}) async {
-    final response = await http.post(url, json.encode(body), headers: authHeader(header: headers));
+
+  Future<http.Response> post(dynamic body,
+      {Map<String, String> headers}) async {
+    final response = await http.post(url,
+        body: json.encode(body), headers: authHeader(header: headers));
     handleStatusCode(response);
     return response;
   }
-  Future<http.Response> patch(dynamic body, {Map<String, String> headers}) async {
-    final response = await http.patch(url, json.encode(body), headers: authHeader(header: headers));
+
+  Future<http.Response> patch(dynamic body,
+      {Map<String, String> headers}) async {
+    final response = await http.patch(url,
+        body: json.encode(body), headers: authHeader(header: headers));
     handleStatusCode(response);
     return response;
   }
+
   Future<http.Response> put(dynamic body, {Map<String, String> headers}) async {
-    final response = await http.put(url, json.encode(body), headers: authHeader(header: headers));
+    final response = await http.put(url,
+        body: json.encode(body), headers: authHeader(header: headers));
     handleStatusCode(response);
     return response;
   }
@@ -80,5 +91,6 @@ class Packet {
 
   Packet({this.opcode, this.data, this.seq, this.event, this.client});
 
-  String toString() => json.encode({"op": opcode, "d": data, "s": seq, "t": event});
+  String toString() =>
+      json.encode({"op": opcode, "d": data, "s": seq, "t": event});
 }

--- a/lib/src/object.dart
+++ b/lib/src/object.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../dartsicord.dart';
 
 abstract class _Resource {
   /// ID of the object.
@@ -14,10 +14,9 @@ class Snowflake {
   String toString() => id.toString();
 
   Snowflake(dynamic id) {
-    this.id = id is String ? int.parse(id) : id;
+    this.id = id is String ? int.parse(id) : id as int;
   }
-  
+
   int get hashCode => id.hashCode;
   bool operator ==(dynamic idOther) => id.toString() == idOther.toString();
 }
-

--- a/lib/src/objects/channel.dart
+++ b/lib/src/objects/channel.dart
@@ -1,9 +1,9 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Channel resource. Could potentially be any of [ChannelType].
 abstract class Channel extends _Resource {
   _Route get _endpoint => client.api + "channels" + id;
-  
+
   /// Name of the channel.
   String name;
 
@@ -27,12 +27,13 @@ abstract class Channel extends _Resource {
     4: ChannelType.guildCategory
   };
 
-  static Future<Channel> _fromMap(Map<String, dynamic> obj, DiscordClient client) async {
+  static Future<T> _fromMap<T extends Channel>(
+      Map<String, dynamic> obj, DiscordClient client) {
     final type = obj["type"];
     if (type == 2)
-      return VoiceChannel._fromMap(obj, client);
+      return VoiceChannel._fromMap(obj, client) as Future<T>;
     else
-      return TextChannel._fromMap(obj, client);
+      return TextChannel._fromMap(obj, client) as Future<T>;
   }
 }
 
@@ -45,7 +46,7 @@ class TextChannel extends Channel {
 
   /// Guild of the channel, if any. Refer to the [type] property and check for [ChannelType.guildText].
   Guild guild;
-  
+
   /// Position of the channel. Refer to the [type] property and check for [ChannelType.guildText].
   int position;
 
@@ -68,11 +69,15 @@ class TextChannel extends Channel {
   List<Overwrite> overwrites = [];
 
   /// Deletes this channel.
-  Future<Null> delete() =>
-    _endpoint.delete();
+  Future<void> delete() => _endpoint.delete();
 
   /// Modifies this channel using the given positional parameters [name], [position], [topic], [newOverwrites], and [nsfw].
-  Future<Null> modify({String name, int position, String topic, List<Overwrite> newOverwrites, bool nsfw}) async {
+  Future<Null> modify(
+      {String name,
+      int position,
+      String topic,
+      List<Overwrite> newOverwrites,
+      bool nsfw}) async {
     final query = {
       "name": name,
       "position": position,
@@ -80,52 +85,61 @@ class TextChannel extends Channel {
       "nsfw": nsfw,
       "permission_overwrites": newOverwrites.map((o) => o._toMap())
     };
-    
-    final response = await _endpoint.patch(query);
-    final map = json.decode(await response.readAsString());
 
-    this.name = map["name"];
-    this.position = map["position"];
-    this.topic = map["topic"];
-    this.nsfw = map["nsfw"];
-    overwrites = map["permission_overwrites"].map(Overwrite._fromMap);
+    final response = await _endpoint.patch(query);
+    final map = json.decode(response.body);
+
+    this.name = map["name"] as String;
+    this.position = map["position"] as int;
+    this.topic = map["topic"] as String;
+    this.nsfw = map["nsfw"] as bool;
+    final permissionOverwrites =
+        (map["permission_overwrites"] as List).cast<Map<String, dynamic>>();
+    overwrites = permissionOverwrites.map(Overwrite._fromMap).toList();
   }
 
   /// Creates a [Webhook] for this channel named [name] using the given positional parameter [avatar].
   Future<Webhook> createWebhook(String name, {String avatar}) async {
-    final query = {
-      "name": name,
-      "avatar": avatar
-    };
+    final query = {"name": name, "avatar": avatar};
 
-    final _Route = _endpoint + "webhooks";
-    final response = await _Route.post(query);
-    return Webhook._fromMap(json.decode(await response.readAsString()), client);
+    final route = _endpoint + "webhooks";
+    final response = await route.post(query);
+    final Map<String, dynamic> data = json.decode(response.body);
+    return Webhook._fromMap(data, client);
   }
 
   /// Modify [existingOverwrite]. If either [newAllow] or [newDeny] are specified, they will completely overwrite
   /// the old allow/deny, so do not rely on this to add new permissions.
-  Future<Null> modifyPermission({Overwrite existingOverwrite, List<RolePermission> newAllow, List<RolePermission> newDeny, OverwriteType type}) async {
+  Future<Null> modifyPermission(
+      {Overwrite existingOverwrite,
+      List<RolePermission> newAllow,
+      List<RolePermission> newDeny,
+      OverwriteType type}) async {
     final query = {
       "allow": Role._permissionToRaw(newAllow),
       "deny": Role._permissionToRaw(newDeny),
-      "type": (new Map.fromIterables(Overwrite.internalMap.values, Overwrite.internalMap.keys))[type]
+      "type": (new Map.fromIterables(
+          Overwrite.internalMap.values, Overwrite.internalMap.keys))[type]
     };
     await (_endpoint + "permissions" + existingOverwrite.targetId).put(query);
   }
 
   /// Fire a typing request to this channel.
-  Future<Null> startTyping() =>
-    (_endpoint + "typing").post({});
+  Future<void> startTyping() => (_endpoint + "typing").post({});
 
   /// Gets a [List] of [Invite] objects that this channel possesses.
   Future<List<Invite>> getInvites() async {
     final response = await (_endpoint + "invites").get();
-    return json.decode(await response.readAsString()).map((i) => Invite._fromMap(i, client));
+    return Future.wait((json.decode(response.body) as List)
+        .map((i) => Invite._fromMap(i as Map<String, dynamic>, client)));
   }
 
   /// Creates a new [Invite] for this channel using the given positional parameters [maxAge], [maxUses], [temporary], and [unique].
-  Future<Invite> createInvite({Duration maxAge, int maxUses = 0, bool temporary = false, bool unique = false}) async {
+  Future<Invite> createInvite(
+      {Duration maxAge,
+      int maxUses = 0,
+      bool temporary = false,
+      bool unique = false}) async {
     maxAge ??= const Duration(hours: 24);
 
     final query = {
@@ -136,21 +150,27 @@ class TextChannel extends Channel {
     };
 
     final response = await (_endpoint + "invites").post(query);
-    return Invite._fromMap(json.decode(await response.readAsString()), client);
+    final Map<String, dynamic> data = json.decode(response.body);
+    return Invite._fromMap(data, client);
   }
 
   /// Gets a [List] of [Message] objects that represent the pins in this channel.
   Future<List<Message>> getPins() async {
     final response = await (_endpoint + "pins").get();
-    return Future.wait(json.decode(await response.readAsString()).map((m) async => await Message._fromMap(m, client)));
+    final data =
+        (json.decode(response.body) as List).cast<Map<String, dynamic>>();
+    return Future.wait(data.map((m) => Message._fromMap(m, client)));
   }
 
   /// Gets a [List] of [Message] objects given the [limit].
-  /// 
+  ///
   /// Optionally, you can specify [downloadType] which is a [MessageDownloadType]
   /// to specify where messages should be searched. To use this feature, the
   /// positional parameter [base] must be given.
-  Future<List<Message>> getMessages({int limit = 50, MessageDownloadType downloadType = MessageDownloadType.after, Message base}) async {
+  Future<List<Message>> getMessages(
+      {int limit = 50,
+      MessageDownloadType downloadType = MessageDownloadType.after,
+      Message base}) async {
     var query = "?limit=$limit";
 
     if (base != null) {
@@ -167,21 +187,24 @@ class TextChannel extends Channel {
           break;
       }
     }
-    
-    final _Route = _endpoint + "messages"
-     ..url += query;
-    final response = await _Route.get();
-    return Future.wait(json.decode(await response.readAsString()).map((m) async => await Message._fromMap(m, client)));
+
+    final route = _endpoint + "messages"
+      ..url += query;
+    final response = await route.get();
+    final data =
+        (json.decode(response.body) as List).cast<Map<String, dynamic>>();
+    return Future.wait(data.map((m) => Message._fromMap(m, client)));
   }
 
   /// Gets a [Message] object given the [id].
   Future<Message> getMessage(dynamic id) async {
     final response = await (_endpoint + "messages" + id).get();
-    return await Message._fromMap(json.decode(await response.readAsString()), client);
+    return await Message._fromMap(
+        json.decode(response.body) as Map<String, dynamic>, client);
   }
 
   /// Bulk-deletes a [List] of [Message] objects from this channel.
-  /// 
+  ///
   /// 2-100 messages may be specified. Messages older than 2 weeks are unaffected.
   Future<Null> bulkDeleteMessages(List<Message> messages) async {
     final query = {"messages": messages.map((m) => m.id.id).toList()};
@@ -189,46 +212,61 @@ class TextChannel extends Channel {
   }
 
   /// Send a message to this channel.
-  /// 
+  ///
   /// [content] is required. If you wish to send an [Embed], you must leave it blank ("").
   /// If you want to specify an [Embed], you first need to build an embed using the [Embed] object.
   /// Documentation for embed building is within the [Embed] object.
   Future<Message> sendMessage(String content, {Embed embed}) async {
-    final query = {
-      "content": content,
-      "embed": embed?._toMap()
-    };
+    final query = {"content": content, "embed": embed?._toMap()};
     final response = await (_endpoint + "messages").post(query);
-    final parsed = json.decode(await response.readAsString());
+    final Map<String, dynamic> parsed = json.decode(response.body);
     return (await Message._fromMap(parsed, client))..author = client.user;
   }
 
-  TextChannel._raw(this.name, this.id, this.type, {this.guild, this.recipients});
+  TextChannel._raw(this.name, this.id, this.type,
+      {this.guild, this.recipients});
 
-  static Future<TextChannel> _fromMap(Map<String, dynamic> obj, DiscordClient client, {Guild guild}) async {
+  static Future<TextChannel> _fromMap(
+      Map<String, dynamic> obj, DiscordClient client,
+      {Guild guild}) async {
     final channelType = Channel.types[obj["type"]];
     switch (channelType) {
       case ChannelType.guildText:
-        final channel = new TextChannel._raw(obj["name"], new Snowflake(obj["id"]), channelType,
-          guild: guild != null ? guild : (obj["guild_id"] != null ? client.getGuild(obj["guild_id"]) : null))
+        final channel = new TextChannel._raw(
+            obj["name"] as String, new Snowflake(obj["id"]), channelType,
+            guild: guild != null
+                ? guild
+                : (obj["guild_id"] != null
+                    ? client.getGuild(obj["guild_id"])
+                    : null))
           ..client = client;
-          for (int i = 0; i < obj["permission_overwrites"].length; i++)
-            channel.overwrites.add(Overwrite._fromMap(obj["permission_overwrites"][i], client));
+        final permissionOverwrites =
+            (obj["permission_overwrites"] as List).cast<Map<String, dynamic>>();
+        for (int i = 0; i < permissionOverwrites.length; i++)
+          channel.overwrites.add(Overwrite._fromMap(permissionOverwrites[i]));
         return channel;
 
       case ChannelType.dm:
-        final users = [];
-        for (int i = 0; i < obj["recipients"].length; i++)
-          users.add(await User._fromMap(obj["recipients"][i], client));
-        final channel = new TextChannel._raw("DM", new Snowflake(obj["id"]), channelType, recipients: users)
+        final users = <User>[];
+        final recipients =
+            (obj["recipients"] as List).cast<Map<String, dynamic>>();
+        for (int i = 0; i < recipients.length; i++)
+          users.add(await User._fromMap(recipients[i], client));
+        final channel = new TextChannel._raw(
+            "DM", new Snowflake(obj["id"]), channelType,
+            recipients: users)
           ..client = client;
         return channel;
 
       case ChannelType.groupDm:
-        final users = [];
-        for (int i = 0; i < obj["recipients"].length; i++)
-          users.add(await User._fromMap(obj["recipients"][i], client));
-        final channel = new TextChannel._raw("GroupDM", new Snowflake(obj["id"]), channelType, recipients: users)
+        final users = <User>[];
+        final recipients =
+            (obj["recipients"] as List).cast<Map<String, dynamic>>();
+        for (int i = 0; i < recipients.length; i++)
+          users.add(await User._fromMap(recipients[i], client));
+        final channel = new TextChannel._raw(
+            "GroupDM", new Snowflake(obj["id"]), channelType,
+            recipients: users)
           ..client = client;
         return channel;
 
@@ -251,6 +289,8 @@ class VoiceChannel extends Channel {
 
   VoiceChannel(this.name, this.id);
 
-  static Future<VoiceChannel> _fromMap(Map<String, dynamic> obj, DiscordClient client, {Guild guild}) =>
-    null;
+  static Future<VoiceChannel> _fromMap(
+          Map<String, dynamic> obj, DiscordClient client,
+          {Guild guild}) =>
+      null;
 }

--- a/lib/src/objects/embed.dart
+++ b/lib/src/objects/embed.dart
@@ -1,57 +1,92 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// An Embed object. Can be self-assembled and sent.
 class Embed {
   /// The title of the embed.
   String title;
+
   /// The type of the embed. Defaults to `rich`.
   String type = "rich";
+
   /// The description of the embed.
   String description;
+
   /// The url of the embed.
   String url;
+
   /// The color of the embed. Use hexadecimal to define this property.
   int color;
 
   /// The [EmbedFooter] linked to this embed.
   EmbedFooter footer;
+
   /// The [EmbedImage] linked to this embed.
   EmbedImage image;
+
   /// The [EmbedThumbnail] linked to this embed.
   EmbedThumbnail thumbnail;
+
   /// The [EmbedVideo] linked to this embed.
   EmbedVideo video;
+
   /// The [EmbedProvider] linked to this embed.
   EmbedProvider provider;
+
   /// The [EmbedAuthor] linked to this embed.
   EmbedAuthor author;
+
   /// A [List] of [EmbedField] objects linked to this embed.
   List<EmbedField> fields = [];
 
-  Embed({this.title, this.description, this.url, this.color, this.footer, this.image, this.thumbnail, this.video, this.provider, this.author, this.fields});
+  Embed(
+      {this.title,
+      this.description,
+      this.url,
+      this.color,
+      this.footer,
+      this.image,
+      this.thumbnail,
+      this.video,
+      this.provider,
+      this.author,
+      this.fields});
 
   /// Give this embed a title.
   void withTitle(String title) => this.title = title;
+
   /// Give this embed a description.
   void withDescription(String description) => this.description = description;
+
   /// Give this embed a clickable URL.
   void withUrl(String url) => this.url = url;
+
   /// Give this embed a color.
   void withColor(int color) => this.color = color;
+
   /// Give this embed a footer, given [text] and [iconUrl].
-  void withFooter(String text, {String iconUrl}) => footer = new EmbedFooter(text, iconUrl: iconUrl);
+  void withFooter(String text, {String iconUrl}) =>
+      footer = new EmbedFooter(text, iconUrl: iconUrl);
+
   /// Give this embed an image, given [url].
   void withImage(String url) => image = new EmbedImage(url);
+
   /// Give this embed a thumbnail, given [url].
   void withThumbnail(String url) => thumbnail = new EmbedThumbnail(url);
+
   /// Give this embed a video, given [url].
   void withVideo(String url) => video = new EmbedVideo(url);
+
   /// Give this embed a provider, given [name] and [url].
-  void withProvider(String name, String url) => provider = new EmbedProvider(name, url);
+  void withProvider(String name, String url) =>
+      provider = new EmbedProvider(name, url);
+
   /// Give this embed an author, given [name], [url], and [iconUrl].
-  void withAuthor(String name, {String url, String iconUrl}) => new EmbedAuthor(name, url: url, iconUrl: iconUrl);
+  void withAuthor(String name, {String url, String iconUrl}) =>
+      new EmbedAuthor(name, url: url, iconUrl: iconUrl);
+
   /// Add a field to this embed.
-  void addField(String title, dynamic value, {bool inline = false}) => fields.add(new EmbedField(title, value.toString(), inline: inline));
+  void addField(String title, dynamic value, {bool inline = false}) =>
+      fields.add(new EmbedField(title, value.toString(), inline: inline));
 
   /// Converts the object-based embed definition to an internal API-usable JSON-encodable map.
   Map<String, dynamic> _toMap() {
@@ -61,9 +96,7 @@ class Embed {
       "type": type,
       "description": description,
       "url": url,
-
       "color": color,
-
       "footer": footer?._toMap(),
       "image": image?._toMap(),
       "thumbnail": thumbnail?._toMap(),
@@ -72,7 +105,7 @@ class Embed {
       "author": author?._toMap(),
       "fields": fieldsList
     };
-    
+
     return response;
   }
 }
@@ -86,7 +119,8 @@ class EmbedFooter {
   /// The footer of the embed. [text] is required. You may specify [iconUrl].
   EmbedFooter(this.text, {this.iconUrl});
 
-  Map<String, dynamic> _toMap() => {"text": text, "icon_url": iconUrl, "proxy_icon_url": proxyIconUrl};
+  Map<String, dynamic> _toMap() =>
+      {"text": text, "icon_url": iconUrl, "proxy_icon_url": proxyIconUrl};
 }
 
 /// An [Embed] image object. Can be self-assembled for an [Embed], or chained on the original [Embed].
@@ -99,7 +133,8 @@ class EmbedImage {
   /// The image of the embed. [url] is required.
   EmbedImage(this.url, {this.height, this.width, this.proxyUrl});
 
-  Map<String, dynamic> _toMap() => {"url": url, "proxy_url": proxyUrl, "height": height, "width": width};
+  Map<String, dynamic> _toMap() =>
+      {"url": url, "proxy_url": proxyUrl, "height": height, "width": width};
 }
 
 /// An [Embed] thumbnail object. Can be self-assembled for an [Embed], or chained on the original [Embed].
@@ -111,8 +146,9 @@ class EmbedThumbnail {
 
   /// The thumbnail of the embed. [url] is required.
   EmbedThumbnail(this.url, {this.height, this.width, this.proxyUrl});
-  
-  Map<String, dynamic> _toMap() => {"url": url, "proxy_url": proxyUrl, "height": height, "width": width};
+
+  Map<String, dynamic> _toMap() =>
+      {"url": url, "proxy_url": proxyUrl, "height": height, "width": width};
 }
 
 /// An [Embed] video object. Can be self-assembled for an [Embed], or chained on the original [Embed].
@@ -124,7 +160,8 @@ class EmbedVideo {
   /// The video of the embed. [url] is required.
   EmbedVideo(this.url);
 
-  Map<String, dynamic> _toMap() => {"url": url, "height": height, "width": width};
+  Map<String, dynamic> _toMap() =>
+      {"url": url, "height": height, "width": width};
 }
 
 /// An [Embed] provider object. Can be self-assembled for an [Embed], or chained on the original [Embed].
@@ -148,7 +185,12 @@ class EmbedAuthor {
   /// The author of the embed. [name] and [url] are required. You may specify [iconUrl].
   EmbedAuthor(this.name, {this.url, this.iconUrl});
 
-  Map<String, dynamic> _toMap() => {"name": name, "url": url, "icon_url": iconUrl, "proxy_icon_url": proxyIconUrl};
+  Map<String, dynamic> _toMap() => {
+        "name": name,
+        "url": url,
+        "icon_url": iconUrl,
+        "proxy_icon_url": proxyIconUrl
+      };
 }
 
 /// An [Embed] field object. Can be self-assembled for an [Embed], or chained on the original [Embed].
@@ -160,5 +202,6 @@ class EmbedField {
   /// A field (of many) in the embed. [name] and [value] are required. You may specify [inline].
   EmbedField(this.name, this.value, {this.inline = false});
 
-  Map<String, dynamic> _toMap() => {"name": name, "value": value, "inline": inline};
+  Map<String, dynamic> _toMap() =>
+      {"name": name, "value": value, "inline": inline};
 }

--- a/lib/src/objects/emoji.dart
+++ b/lib/src/objects/emoji.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// An Emoji resource. Can correspond to a guild or be a global emoji.
 class Emoji extends _Resource {
@@ -9,7 +9,7 @@ class Emoji extends _Resource {
 
   /// Whether or not this emoji requires colons to type.
   bool requiresColons;
-  
+
   /// Whether or not this emoji is managed.
   bool managed;
 
@@ -22,22 +22,32 @@ class Emoji extends _Resource {
   /// The user that created this emoji.
   User author;
 
-  Emoji(this.name, {this.id, this.guild, this.roles, this.author, this.requiresColons, this.managed});
+  Emoji(this.name,
+      {this.id,
+      this.guild,
+      this.roles,
+      this.author,
+      this.requiresColons,
+      this.managed});
 
-  String toString() =>
-    id == null ? name : id.toString();
+  String toString() => id == null ? name : id.toString();
 
-  static Future<Emoji> _fromMap(Map<String, dynamic> obj, DiscordClient client, {Guild guild}) async {
-    final emoji = new Emoji(obj["name"], id: new Snowflake(obj["id"]),
-      guild: guild,
-      author: obj["user"] != null ? await User._fromMap(obj["user"], client) : null,
-      requiresColons: obj["requires_colons"],
-      managed: obj["managed"])
+  static Future<Emoji> _fromMap(Map<String, dynamic> obj, DiscordClient client,
+      {Guild guild}) async {
+    final emoji = new Emoji(obj["name"] as String,
+        id: new Snowflake(obj["id"]),
+        guild: guild,
+        author: obj["user"] != null
+            ? await User._fromMap(obj["user"] as Map<String, dynamic>, client)
+            : null,
+        requiresColons: obj["requires_colons"] as bool,
+        managed: obj["managed"] as bool)
       ..client = client;
-    
+
     if (obj.containsKey("roles")) {
-      for (int i = 0; i < obj["roles"].length; i++) {
-        final role = await Role._fromMap(obj["roles"][i], client)
+      final roles = (obj["roles"] as List).cast<Map<String, dynamic>>();
+      for (int i = 0; i < roles.length; i++) {
+        final role = await Role._fromMap(roles[i], client)
           ..guild = guild;
         emoji.roles.add(role);
       }

--- a/lib/src/objects/game.dart
+++ b/lib/src/objects/game.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Game resource. Can be self-assembled to set the game.
 class Game extends _Resource {
@@ -16,25 +16,25 @@ class Game extends _Resource {
     3: ActivityType.watch
   };
   static Map<ActivityType, int> get activitiesInverse =>
-    new Map.fromIterables(activities.values, activities.keys);
+      new Map.fromIterables(activities.values, activities.keys);
   static Map<StatusType, String> get statusesInverse =>
-    new Map.fromIterables(statuses.values, statuses.keys);
-  static Future<Game> _fromMap(Map<String, dynamic> obj, DiscordClient client) async =>
-    new Game(obj["name"], Game.activities[obj["type"]],
-      streamUrl: obj["url"] != null ? Uri.parse(obj["url"]) : null)
-      ..client = client;
+      new Map.fromIterables(statuses.values, statuses.keys);
+  static Future<Game> _fromMap(
+          Map<String, dynamic> obj, DiscordClient client) async =>
+      new Game(obj["name"] as String, Game.activities[obj["type"]],
+          streamUrl:
+              obj["url"] != null ? Uri.parse(obj["url"] as String) : null)
+        ..client = client;
 
   String name;
   Uri streamUrl;
   ActivityType type;
 
   Game(this.name, this.type, {this.streamUrl});
-  
-  Map<String, dynamic> _toMap() =>
-    {
-      "name": name,
-      "type": Game.activitiesInverse[type],
-      "url": streamUrl?.toString()
-    };
-}
 
+  Map<String, dynamic> _toMap() => {
+        "name": name,
+        "type": Game.activitiesInverse[type],
+        "url": streamUrl?.toString()
+      };
+}

--- a/lib/src/objects/guild.dart
+++ b/lib/src/objects/guild.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Guild resource. Contains information on what is known as a Server through Discord.
 class Guild extends _Resource {
@@ -16,7 +16,8 @@ class Guild extends _Resource {
   List<Channel> channels = [];
 
   /// A list of [TextChannel] objects, derived from the [channels] property.
-  List<TextChannel> get textChannels => channels.where((c) => c is TextChannel);
+  List<TextChannel> get textChannels =>
+      channels.whereType<TextChannel>().toList();
 
   /// A list of [Role] objects that the guild has.
   List<Role> roles = [];
@@ -25,38 +26,39 @@ class Guild extends _Resource {
   List<Emoji> emojis = [];
 
   /// A list of [Webhook] objects that the guild has.
-  List<Webhook> get webhooks => textChannels.fold([], (p, c) => p..addAll(c.webhooks));
+  List<Webhook> get webhooks =>
+      textChannels.fold([], (p, c) => p..addAll(c.webhooks));
 
   /// Leave this guild.
-  Future<Null> leave() =>
-    (client.api + "users" + "@me" + "guilds" + id).delete();
+  Future<void> leave() =>
+      (client.api + "users" + "@me" + "guilds" + id).delete();
 
   /// Retrieves a Member object from a User object.
   Future<Member> getMember(User user) async {
     final response = await (_endpoint + "members" + user.id).get();
-    return Member._fromMap(json.decode(await response.readAsString()), client, this);
+    final Map<String, dynamic> data = json.decode(response.body);
+    return Member._fromMap(data, client, this);
   }
 
   /// Kick a member from this guild.
-  Future<Null> kickMember(Member member) =>
-    (_endpoint + "members" + member.id).delete();
+  Future<void> kickMember(Member member) =>
+      (_endpoint + "members" + member.id).delete();
 
   /// Ban a member from this guild.
-  Future<Null> banMember(Member member, {int deleteMessageDays}) =>
-    (_endpoint + "bans" + member.id).put({"delete-message-days": deleteMessageDays});
+  Future<void> banMember(Member member, {int deleteMessageDays}) =>
+      (_endpoint + "bans" + member.id)
+          .put({"delete-message-days": deleteMessageDays});
 
   /// Ban a user's ID from this guild.
-  Future<Null> banId(int userId) =>
-    (_endpoint + "bans" + userId).put({});
+  Future<void> banId(int userId) => (_endpoint + "bans" + userId).put({});
 
   /// Creates a role for this guild using the given positional parameters [name], [permissions], [color], [hoisted], and [mentionable].
-  Future<Role> createRole({
-    String name = "new role",
-    List<RolePermission> permissions,
-    int color = 0,
-    bool hoisted = false,
-    bool mentionable = false
-  }) async {
+  Future<Role> createRole(
+      {String name = "new role",
+      List<RolePermission> permissions,
+      int color = 0,
+      bool hoisted = false,
+      bool mentionable = false}) async {
     permissions ??= [];
 
     final query = {
@@ -68,31 +70,30 @@ class Guild extends _Resource {
     };
 
     final response = await (_endpoint + "roles").post(query);
-    return Role._fromMap(json.decode(await response.readAsString()), client);
+    final Map<String, dynamic> data = json.decode(response.body);
+    return Role._fromMap(data, client);
   }
 
   /// Give a member a role.
-  Future<Null> addMemberRole(Member member, Role role) =>
-    (_endpoint + "members" + member.id + "roles" + role.id).put({});
+  Future<void> addMemberRole(Member member, Role role) =>
+      (_endpoint + "members" + member.id + "roles" + role.id).put({});
 
   /// Remove a role from a member.
-  Future<Null> removeMemberRole(Member member, Role role) =>
-    (_endpoint + "members" + member.id + "roles" + role.id).delete();
+  Future<void> removeMemberRole(Member member, Role role) =>
+      (_endpoint + "members" + member.id + "roles" + role.id).delete();
 
   /// Modify an existing emoji.
-  Future<Null> modifyEmoji(Emoji emoji, {String name, List<Role> roles}) =>
-    (_endpoint + "emojis" + emoji.id).patch({
-      "name": name,
-      "roles": roles
-    });
+  Future<void> modifyEmoji(Emoji emoji, {String name, List<Role> roles}) =>
+      (_endpoint + "emojis" + emoji.id).patch({"name": name, "roles": roles});
 
   /// Delete an existing emoji.
-  Future<Null> deleteEmoji(Emoji emoji) =>
-    (_endpoint + "emojis" + emoji.id).delete();
+  Future<void> deleteEmoji(Emoji emoji) =>
+      (_endpoint + "emojis" + emoji.id).delete();
 
   /// Creates a webhook. See [TextChannel.createWebhook] for further documentation.
-  Future<Webhook> createWebhook(TextChannel channel, String name, {String avatar}) =>
-    channel.createWebhook(name, avatar: avatar);
+  Future<Webhook> createWebhook(TextChannel channel, String name,
+          {String avatar}) =>
+      channel.createWebhook(name, avatar: avatar);
 
   //
   // Constructors
@@ -101,57 +102,62 @@ class Guild extends _Resource {
   Guild._raw(this.name, this.id, {this.partial});
 
   Future<Null> download() async {
-    if (!partial)
-      return;
+    if (!partial) return;
 
     final response = await _endpoint.get();
 
-    final obj = json.decode(await response.readAsString());
-    if (obj["channels"] != null) {
-        for(int i = 0; i < obj["channels"].length; i++) {
-          if (obj["channels"][i]["type"] != 0)
-            continue;
-          final channel = await TextChannel._fromMap(obj["channels"][i], client, guild: this);
-          channels.add(channel);
-        }
+    final obj = json.decode(response.body);
+    final channelsData = (obj["channels"] as List).cast<Map<String, dynamic>>();
+    if (channelsData != null) {
+      for (int i = 0; i < channelsData.length; i++) {
+        if (channelsData[i]["type"] != 0) continue;
+        final channel =
+            await TextChannel._fromMap(channelsData[i], client, guild: this);
+        channels.add(channel);
       }
-      if (obj["roles"] != null) {
-        for(int i = 0; i < obj["roles"].length; i++) {
-          final role = Role._fromMap(obj["roles"][i], client)
-            ..guild = this;
-          roles.add(role);
-        }
+    }
+    final rolesData = (obj["roles"] as List).cast<Map<String, dynamic>>();
+    if (rolesData != null) {
+      for (int i = 0; i < rolesData.length; i++) {
+        final role = Role._fromMap(rolesData[i], client)..guild = this;
+        roles.add(role);
       }
+    }
   }
 
-  static Future<Guild> _fromMap(Map<String, dynamic> obj, DiscordClient client) async {
+  static Future<Guild> _fromMap(
+      Map<String, dynamic> obj, DiscordClient client) async {
     if (obj["unavailable"] == null || obj["unavailable"] == false) {
-      final g = new Guild._raw(obj["name"], new Snowflake(obj["id"]))
+      final g = new Guild._raw(obj["name"] as String, new Snowflake(obj["id"]))
         ..client = client;
 
-      if (obj["emojis"] != null) {
-        for (int i = 0; i < obj["emojis"].length; i++) {
-          final emoji = await Emoji._fromMap(obj["emojis"][i], client, guild: g);
+      final emojisData = (obj["emojis"] as List).cast<Map<String, dynamic>>();
+      if (emojisData != null) {
+        for (int i = 0; i < emojisData.length; i++) {
+          final emoji = await Emoji._fromMap(emojisData[i], client, guild: g);
           g.emojis.add(emoji);
         }
       }
-      if (obj["channels"] != null) {
-        for(int i = 0; i < obj["channels"].length; i++) {
-          if (obj["channels"][i]["type"] != 0)
-            continue;
-          final channel = await TextChannel._fromMap(obj["channels"][i], client, guild: g);
+      final channelsData =
+          (obj["channels"] as List).cast<Map<String, dynamic>>();
+      if (channelsData != null) {
+        for (int i = 0; i < channelsData.length; i++) {
+          if (channelsData[i]["type"] != 0) continue;
+          final channel =
+              await TextChannel._fromMap(channelsData[i], client, guild: g);
           g.channels.add(channel);
         }
       }
-      if (obj["roles"] != null) {
-        for(int i = 0; i < obj["roles"].length; i++) {
-          final role = Role._fromMap(obj["roles"][i], client)
-            ..guild = g;
+      final rolesData = (obj["roles"] as List).cast<Map<String, dynamic>>();
+      if (rolesData != null) {
+        for (int i = 0; i < rolesData.length; i++) {
+          final role = Role._fromMap(rolesData[i], client)..guild = g;
           g.roles.add(role);
         }
       }
       return g;
-    } else { // This is a partial guild. A lot of features will be missing and must be [download]'ed.
+    } else {
+      // This is a partial guild. A lot of features will be missing and must be [download]'ed.
       return new Guild._raw(null, new Snowflake(obj["id"]), partial: true);
     }
   }

--- a/lib/src/objects/invite.dart
+++ b/lib/src/objects/invite.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// An Invite object. Create with [TextChannel.createInvite].
 class Invite {
@@ -6,52 +6,70 @@ class Invite {
 
   /// The code of the invite.
   String code;
+
   /// The guild of the invite. This object is likely partial; it may need to be `download` ed.
   Guild guild;
+
   /// The channel of the invite. This object is likely partial; it may need to be `download` ed.
   TextChannel channel;
-  
+
   /// The total number of uses on this invite.
   int uses;
+
   /// The maximum number of uses on this invite.
   int maxUses;
+
   /// Whether or not this invite only grants temporary access.
   bool temporary;
+
   /// Whether or not this invite is revoked.
   bool revoked;
+
   /// The time at which this invite was created.
   DateTime createdAt;
+
   /// The maximum duration at which this invite can be used.
   Duration maxAge;
+
   /// The [User] object who created this invite.
   User inviter;
 
   /// The client associated with the invite.
-  DiscordClient client; // It's not an actual Resource, so I can't implement the class...
+  DiscordClient
+      client; // It's not an actual Resource, so I can't implement the class...
 
-  Invite._raw(this.code, {this.guild, this.channel,
-    this.uses, this.maxUses, this.temporary, this.revoked, this.createdAt, this.maxAge, this.inviter});
+  Invite._raw(this.code,
+      {this.guild,
+      this.channel,
+      this.uses,
+      this.maxUses,
+      this.temporary,
+      this.revoked,
+      this.createdAt,
+      this.maxAge,
+      this.inviter});
 
-  Future<Null> accept() =>
-    _endpoint.post({});
-  
-  Future<Null> delete() =>
-    _endpoint.delete();
+  Future<void> accept() => _endpoint.post({});
 
-  static Future<Invite> _fromMap(Map<String, dynamic> obj, DiscordClient client) async {
-    final inv = new Invite._raw(obj["code"],
-      guild: client.getGuild(obj["guild"]["id"]),
-      channel: await client.getTextChannel(obj["channel"]["id"]));
+  Future<void> delete() => _endpoint.delete();
 
-    if (obj["inviter"] != null) { // Includes metadata.
+  static Future<Invite> _fromMap(
+      Map<String, dynamic> obj, DiscordClient client) async {
+    final inv = new Invite._raw(obj["code"] as String,
+        guild: client.getGuild(obj["guild"]["id"]),
+        channel: await client.getTextChannel(obj["channel"]["id"]));
+
+    final Map<String, dynamic> inviterData = obj["inviter"];
+    if (inviterData != null) {
+      // Includes metadata.
       inv
-        ..inviter = await User._fromMap(obj["inviter"], client)
-        ..uses = obj["uses"]
-        ..maxUses = obj["max_uses"]
-        ..maxAge = new Duration(seconds: obj["max_age"])
-        ..temporary = obj["temporary"]
-        ..createdAt = DateTime.parse(obj["created_at"])
-        ..revoked = obj["revoked"];
+        ..inviter = await User._fromMap(inviterData, client)
+        ..uses = obj["uses"] as int
+        ..maxUses = obj["max_uses"] as int
+        ..maxAge = new Duration(seconds: obj["max_age"] as int)
+        ..temporary = obj["temporary"] as bool
+        ..createdAt = DateTime.parse(obj["created_at"] as String)
+        ..revoked = obj["revoked"] as bool;
     }
 
     return inv;

--- a/lib/src/objects/message.dart
+++ b/lib/src/objects/message.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Message resource. Create with [TextChannel.sendMessage] or [DiscordClient.sendMessage].
 class Message extends _Resource {
@@ -36,96 +36,102 @@ class Message extends _Resource {
 
   Snowflake id;
 
-
-
   //
   // Methods
   //
 
   /// React to the message using [emoji].
-  /// 
+  ///
   /// You can use [Guild.emojis] to find the emoji you'd like to use,
   /// or you can instantiate an Emoji object yourself given the name,
   /// which can be raw emoji unicode. For example, `new Emoji("🎊")`
-  Future<Null> react(Emoji emoji) =>
-    (_endpoint + "reactions" + emoji + "@me").put({});
+  Future<void> react(Emoji emoji) =>
+      (_endpoint + "reactions" + emoji + "@me").put({});
 
   /// Removes a previously created reaction from the message using [emoji].
-  /// 
+  ///
   /// See [Message.react] for more information on how to use this method.
-  Future<Null> removeReaction(Emoji emoji) =>
-    (_endpoint + "reactions" + emoji + "@me").delete();
+  Future<void> removeReaction(Emoji emoji) =>
+      (_endpoint + "reactions" + emoji + "@me").delete();
 
   /// Gets all users who reacted to the message using [emoji] given the [limit], if any.
-  /// 
+  ///
   /// [limit] will default to 100. Positional retrieval will be implemented some time soon.
   Future<List<User>> getReactions(Emoji emoji, {int limit = 100}) async {
-    final _Route = _endpoint + "reactions" + emoji
+    final route = _endpoint + "reactions" + emoji
       ..url += "?limit=$limit";
-    final response = await _Route.get();
-    return Future.wait(json.decode(await response.readAsString()).map((u) async => await User._fromMap(u, client)));
+    final response = await route.get();
+    final usersData =
+        (json.decode(response.body) as List).cast<Map<String, dynamic>>();
+    return Future.wait(usersData.map((u) => User._fromMap(u, client)));
   }
 
   /// Deletes all reactions created on this message.
-  Future<Null> deleteReactions() =>
-    (_endpoint + "reactions").delete();
+  Future<void> deleteReactions() => (_endpoint + "reactions").delete();
 
   /// Pin a message to its [channel].
-  Future<Null> pin() =>
-    (channel._endpoint + "pins" + id).put({});
+  Future<void> pin() => (channel._endpoint + "pins" + id).put({});
 
   /// Unpins a message from its [channel].
-  Future<Null> unPin() =>
-    (channel._endpoint + "pins" + id).delete();
+  Future<void> unPin() => (channel._endpoint + "pins" + id).delete();
 
   /// Edit the message, given it is yours.
   Future<Null> edit(String content, {Embed embed}) async {
-    if (!isAuthor)
-      throw new ForbiddenException();
+    if (!isAuthor) throw new ForbiddenException();
 
-    final newMessage = await _endpoint.patch({"content": content, "embed": embed?._toMap()});
+    final newMessage =
+        await _endpoint.patch({"content": content, "embed": embed?._toMap()});
     this.content = content;
     this.embed ??= embed;
-    
-    editedAt = DateTime.parse(json.decode(await newMessage.readAsString())["edited_timestamp"]);
+
+    editedAt = DateTime.parse(
+        json.decode(newMessage.body)["edited_timestamp"] as String);
   }
 
   /// Delete the message.
-  Future<Null> delete() =>
-    _endpoint.delete();
+  Future<void> delete() => _endpoint.delete();
 
   /// Reply to the message. See [DiscordClient.sendMessage] for full documentation.
   Future<Message> reply(String text, {Embed embed}) async =>
-    await channel.sendMessage(text, embed: embed);
+      await channel.sendMessage(text, embed: embed);
 
   //
   // Constructors
   //
 
   Message._raw(this.content, this.id, {this.author, this.channel, this.guild});
-  
-  static Future<Message> _fromMap(Map<String, dynamic> obj, DiscordClient client) async {
-    final message = new Message._raw(obj["content"], new Snowflake(obj["id"]),
-      author: obj["author"] != null ? await User._fromMap(obj["author"], client) : null,
-      channel: await client.getChannel(obj["channel_id"]),
-      guild: (await client.getTextChannel(obj["channel_id"])).guild)
 
-      ..createdAt = DateTime.parse(obj["timestamp"])
-      ..editedAt = obj["edited_timestamp"] != null ? DateTime.parse(obj["edited_timestamp"]) : null
+  static Future<Message> _fromMap(
+      Map<String, dynamic> obj, DiscordClient client) async {
+    final message = new Message._raw(
+        obj["content"] as String, new Snowflake(obj["id"]),
+        author: obj["author"] != null
+            ? await User._fromMap(obj["author"] as Map<String, dynamic>, client)
+            : null,
+        channel: await client.getChannel(obj["channel_id"]),
+        guild: (await client.getTextChannel(obj["channel_id"])).guild)
+      ..createdAt = DateTime.parse(obj["timestamp"] as String)
+      ..editedAt = obj["edited_timestamp"] != null
+          ? DateTime.parse(obj["edited_timestamp"] as String)
+          : null
       ..client = client;
 
-    obj["mentions"]?.forEach((m) async {
+    final mentionsData =
+        ((obj["mentions"] as List) ?? []).cast<Map<String, dynamic>>();
+    for (final m in mentionsData) {
       final user = await User._fromMap(m, client);
 
       message.mentions.add(user);
-    });
+    }
 
-    obj["role_mentions"]?.forEach((m) async {
+    final roleMentionsData =
+        ((obj["role_mentions"] as List) ?? []).cast<Map<String, dynamic>>();
+    for (final m in roleMentionsData) {
       final role = await Role._fromMap(m, client)
         ..guild = message.guild;
 
       message.roleMentions.add(role);
-    });
+    }
 
     return message;
   }

--- a/lib/src/objects/overwrite.dart
+++ b/lib/src/objects/overwrite.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// An Overwrite object. Can be directly created and used with [TextChannel.modify] and [TextChannel.modifyPermission].
 class Overwrite {
@@ -13,23 +13,25 @@ class Overwrite {
 
   /// The type of overwrite this is.
   OverwriteType type;
+
   /// A [List] of [RolePermission] enums to allow.
   List<RolePermission> allow = [];
+
   /// A [List] of [RolePermission] enums to deny.
   List<RolePermission> deny = [];
 
   Overwrite(this.targetId, this.type, {this.allow, this.deny});
 
-  static Overwrite _fromMap(Map<String, dynamic> obj, DiscordClient client) =>
-    new Overwrite(new Snowflake(obj["id"]), Overwrite.internalMap[obj["type"]],
-      allow: Role._permissionFromRaw(obj["allow"]),
-      deny: Role._permissionFromRaw(obj["deny"]));
-  
-  Map<String, dynamic> _toMap() =>
-    {
-      "id": targetId.toString(),
-      "type": (new Map.fromIterables(internalMap.values, internalMap.keys))[type],
-      "allow": Role._permissionToRaw(allow),
-      "deny": Role._permissionToRaw(deny)
-    };
+  static Overwrite _fromMap(Map<String, dynamic> obj) => new Overwrite(
+      new Snowflake(obj["id"]), Overwrite.internalMap[obj["type"]],
+      allow: Role._permissionFromRaw(obj["allow"] as int),
+      deny: Role._permissionFromRaw(obj["deny"] as int));
+
+  Map<String, dynamic> _toMap() => {
+        "id": targetId.toString(),
+        "type":
+            (new Map.fromIterables(internalMap.values, internalMap.keys))[type],
+        "allow": Role._permissionToRaw(allow),
+        "deny": Role._permissionToRaw(deny)
+      };
 }

--- a/lib/src/objects/role.dart
+++ b/lib/src/objects/role.dart
@@ -1,13 +1,14 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Role resource. Create with [Guild.createRole].
 class Role extends _Resource {
   static int _permissionToRaw(List<RolePermission> permissions) =>
-    permissions.fold(0, (p, c) => p + _permissionMap[c]);
+      permissions.fold(0, (p, c) => p + _permissionMap[c]);
 
-  static List<RolePermission> _permissionFromRaw(int raw, {List<RolePermission> preset = RolePermission.values}) =>
-    preset.where((p) => raw & _permissionMap[p] != 0).toList();
-  
+  static List<RolePermission> _permissionFromRaw(int raw,
+          {List<RolePermission> preset = RolePermission.values}) =>
+      preset.where((p) => raw & _permissionMap[p] != 0).toList();
+
   static final Map<RolePermission, int> _permissionMap = {
     RolePermission.createInstantInvite: 1 << 0,
     RolePermission.kickMembers: 1 << 1,
@@ -17,7 +18,6 @@ class Role extends _Resource {
     RolePermission.manageGuild: 1 << 5,
     RolePermission.addReactions: 1 << 6,
     RolePermission.viewAuditLog: 1 << 7,
-
     RolePermission.readMessages: 1 << 10,
     RolePermission.sendMessages: 1 << 11,
     RolePermission.sendTtsMessages: 1 << 12,
@@ -27,7 +27,6 @@ class Role extends _Resource {
     RolePermission.readMessageHistory: 1 << 16,
     RolePermission.mentionEveryone: 1 << 17,
     RolePermission.useExternalEmojis: 1 << 18,
-
     RolePermission.connect: 1 << 20,
     RolePermission.speak: 1 << 21,
     RolePermission.muteMembers: 1 << 22,
@@ -70,15 +69,21 @@ class Role extends _Resource {
   /// Whether or not this role is mentionable.
   bool mentionable;
 
-  Role._raw(this.name, this.id, {this.color, this.hoisted, this.position, this.permissionsRaw, this.managed, this.mentionable, this.guild});
+  Role._raw(this.name, this.id,
+      {this.color,
+      this.hoisted,
+      this.position,
+      this.permissionsRaw,
+      this.managed,
+      this.mentionable,
+      this.guild});
 
-  static Role _fromMap(Map<String, dynamic> obj, DiscordClient client) => 
-    new Role._raw(
-      obj["name"], new Snowflake(obj["id"]),
-      hoisted: obj["hoist"],
-      position: obj["position"],
-      permissionsRaw: obj["permissions"],
-      managed: obj["managed"],
-      mentionable: obj["mentionable"]
-    )..client = client;
+  static Role _fromMap(Map<String, dynamic> obj, DiscordClient client) =>
+      new Role._raw(obj["name"] as String, new Snowflake(obj["id"]),
+          hoisted: obj["hoist"] as bool,
+          position: obj["position"] as int,
+          permissionsRaw: obj["permissions"] as int,
+          managed: obj["managed"] as bool,
+          mentionable: obj["mentionable"] as bool)
+        ..client = client;
 }

--- a/lib/src/objects/user.dart
+++ b/lib/src/objects/user.dart
@@ -1,11 +1,13 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A User resource. Not used for guild membership.
 class User extends _Resource {
-  _Route get _endpoint => client.api + "users" + (id == client.user.id ? "@me" : id);
+  _Route get _endpoint =>
+      client.api + "users" + (id == client.user.id ? "@me" : id);
 
   /// Username of the user.
   String username;
+
   /// Discriminator of the user.
   String discriminator;
 
@@ -14,6 +16,7 @@ class User extends _Resource {
 
   /// The ID of the avatar this user has, if any.
   String avatar;
+
   /// The CDN URL that corresponds to this user's avatar.
   String get avatarUrl => "https://cdn.discordapp.com/avatars/$id/$avatar.png";
 
@@ -25,22 +28,26 @@ class User extends _Resource {
   /// Creates a direct message channel with this user.
   Future<TextChannel> createDirectMessage() async {
     final response = await (_endpoint + "channels").post({"recipient_id": id});
-    final channel = TextChannel._fromMap(json.decode(await response.readAsString()), client);
+    final channel = TextChannel._fromMap(
+        json.decode(response.body) as Map<String, dynamic>, client);
     return channel;
   }
 
   User(this.username, this.discriminator, this.id, {this.avatar});
 
-
-
   static Future<User> get(dynamic id, DiscordClient client) async {
-    final response = await (new _Route(client: client) + "users" + id.toString()).get();
-    return await _fromMap(json.decode(await response.readAsString()), client);
+    final response =
+        await (new _Route(client: client) + "users" + id.toString()).get();
+    return await _fromMap(
+        json.decode(response.body) as Map<String, dynamic>, client);
   }
 
-  static Future<User> _fromMap(Map<String, dynamic> obj, DiscordClient client) async =>
-    new User(obj["username"], obj["discriminator"], new Snowflake(obj["id"]),
-      avatar: obj["avatar"])..client = client;
+  static Future<User> _fromMap(
+          Map<String, dynamic> obj, DiscordClient client) async =>
+      new User(obj["username"] as String, obj["discriminator"] as String,
+          new Snowflake(obj["id"]),
+          avatar: obj["avatar"] as String)
+        ..client = client;
 }
 
 /// A Member resource. Modified [User] object that corresponds to a specific guild. Contains information such as [nickname], [roles], etc.
@@ -52,6 +59,7 @@ class Member extends _Resource {
 
   /// The user representing this member.
   User user;
+
   /// The nickname of the member.
   String nickname;
 
@@ -60,38 +68,42 @@ class Member extends _Resource {
 
   /// Whether or not the user is deafened by the guild.
   bool deafened;
+
   /// Whether or not the user is muted by the guild.
   bool muted;
 
   /// Kicks this member from the parent guild.
-  Future kick() =>
-    guild.kickMember(this);
+  Future kick() => guild.kickMember(this);
 
   /// Bans this member from the parent guild.
   Future ban({int deleteMessageDays}) =>
-    guild.banMember(this, deleteMessageDays: deleteMessageDays);
-  
+      guild.banMember(this, deleteMessageDays: deleteMessageDays);
+
   /// Adds a role to this member.
-  Future addRole(Role role) =>
-    guild.addMemberRole(this, role);
+  Future addRole(Role role) => guild.addMemberRole(this, role);
 
   /// Removes a role from this member.
-  Future removeRole(Role role) =>
-    guild.removeMemberRole(this, role);
+  Future removeRole(Role role) => guild.removeMemberRole(this, role);
 
-  Member._raw(this.user, this.guild, {this.nickname, this.roles, this.deafened, this.muted});
+  Member._raw(this.user, this.guild,
+      {this.nickname, this.roles, this.deafened, this.muted});
 
-  static Future<Member> _fromMap(Map<String, dynamic> obj, DiscordClient client, Guild guild) async {
-    final roleList = [];
-    for (int i = 0; i < obj["roles"].length; i++) {
-      final roleId = obj["roles"][i];
-      final role = guild.roles.firstWhere((r) => r.id.toString() == roleId.toString());
+  static Future<Member> _fromMap(
+      Map<String, dynamic> obj, DiscordClient client, Guild guild) async {
+    final roleList = <Role>[];
+    final List<String> roles = obj["roles"];
+    for (int i = 0; i < roles.length; i++) {
+      final roleId = roles[i];
+      final role =
+          guild.roles.firstWhere((r) => r.id.toString() == roleId.toString());
       roleList.add(role);
     }
-    return new Member._raw(await User._fromMap(obj["user"], client), guild,
-      roles: roleList,
-      nickname: obj["nick"],
-      deafened: obj["deaf"],
-      muted: obj["mute"])..client = client;
+    return new Member._raw(
+        await User._fromMap(obj["user"] as Map<String, dynamic>, client), guild,
+        roles: roleList,
+        nickname: obj["nick"] as String,
+        deafened: obj["deaf"] as bool,
+        muted: obj["mute"] as bool)
+      ..client = client;
   }
 }

--- a/lib/src/objects/webhook.dart
+++ b/lib/src/objects/webhook.dart
@@ -1,4 +1,4 @@
-part of dartsicord;
+part of '../../dartsicord.dart';
 
 /// A Webhook resource. Create with [TextChannel.createWebhook].
 class Webhook extends _Resource {
@@ -8,42 +8,44 @@ class Webhook extends _Resource {
 
   /// The name of the Webhook.
   String name;
+
   /// The avatar of the Webhook.
   String avatar;
+
   /// The secure token of the Webhook.
   String token;
 
   /// The Webhook's creator.
   User author;
+
   /// The Webhook's channel.
   TextChannel channel;
+
   /// The Webhook's guild.
   Guild guild;
 
   /// Delete this webhook.
-  Future<Null> delete() =>
-    _endpoint.delete();
+  Future<void> delete() => _endpoint.delete();
 
   /// Modify this webhook using the given positional parameters [name], [avatar], and [channel].
   Future<Null> modify({String name, String avatar, Channel channel}) async {
     final query = {};
-    if (name != null)
-      query["name"] = name;
-    if (avatar != null)
-      query["avatar"] = avatar;
-    if (channel != null)
-      query["channel_id"] = channel.id.id;
+    if (name != null) query["name"] = name;
+    if (avatar != null) query["avatar"] = avatar;
+    if (channel != null) query["channel_id"] = channel.id.id;
 
     final response = await _endpoint.patch(query);
-    final object = json.decode(await response.readAsString());
+    final object = json.decode(response.body);
 
-    this.name = object["name"];
-    this.avatar = object["avatar"];
-    this.channel = await client.getChannel(object["channel_id"]);
+    this.name = object["name"] as String;
+    this.avatar = object["avatar"] as String;
+    this.channel =
+        await client.getChannel(object["channel_id"] as int) as TextChannel;
   }
 
   /// Execute this webhook.
-  Future<Null> execute(String content, {String username, bool tts, List<Embed> embeds}) async {
+  Future<Null> execute(String content,
+      {String username, bool tts, List<Embed> embeds}) async {
     final query = {
       "content": content,
       "username": username,
@@ -53,11 +55,15 @@ class Webhook extends _Resource {
     await (_endpoint + token).post(query);
   }
 
-  Webhook._raw(this.id, this.name, this.token, {this.avatar, this.channel, this.guild});
+  Webhook._raw(this.id, this.name, this.token,
+      {this.avatar, this.channel, this.guild});
 
-  static Future<Webhook> _fromMap(Map<String, dynamic> obj, DiscordClient client) async =>
-    new Webhook._raw(new Snowflake(obj["id"]), obj["name"], obj["token"],
-      avatar: obj["avatar"],
-      channel: await client.getTextChannel(obj["channel_id"]),
-      guild: obj["guild_id"] != null ? client.getGuild(obj["guild"]) : null);
+  static Future<Webhook> _fromMap(
+          Map<String, dynamic> obj, DiscordClient client) async =>
+      new Webhook._raw(new Snowflake(obj["id"]), obj["name"] as String,
+          obj["token"] as String,
+          avatar: obj["avatar"] as String,
+          channel: await client.getTextChannel(obj["channel_id"]),
+          guild:
+              obj["guild_id"] != null ? client.getGuild(obj["guild"]) : null);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,85 +7,90 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.26.4"
+    version: "0.33.4"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "1.5.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.3"
-  barback:
+    version: "2.0.8"
+  boolean_selector:
     dependency: transitive
     description:
-      name: barback
+      name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2+13"
+    version: "1.0.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.3"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "2.0.6"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7+1"
+    version: "0.14.6"
+  front_end:
+    dependency: transitive
+    description:
+      name: front_end
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.6+6"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.7"
   html:
     dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+2"
+    version: "0.13.3+3"
   http:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "22d2876f72dba30cbfa30cd39be789ff4c5a765e"
-      url: "https://github.com/dart-lang/http"
-    source: git
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.12.0"
   http_multi_server:
     dependency: transitive
@@ -93,160 +98,265 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "2.0.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+8"
+    version: "3.1.3"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.3"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1+1"
+  json_rpc_2:
+    dependency: transitive
+    description:
+      name: json_rpc_2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  kernel:
+    dependency: transitive
+    description:
+      name: kernel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.6+6"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+1"
+    version: "0.11.3+2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+2"
+    version: "0.12.3+1"
+  meta:
+    dependency: transitive
+    description:
+      name: meta
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.6"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.6+2"
+  multi_server_socket:
+    dependency: transitive
+    description:
+      name: multi_server_socket
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.4"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "1.0.5"
+  package_resolver:
+    dependency: transitive
+    description:
+      name: package_resolver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.2"
   plugin:
     dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0+3"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.6"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.3+3"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.8"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+5"
+    version: "0.2.2+4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.5"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.4"
+    version: "0.10.8"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.3"
+  stream_channel:
+    dependency: transitive
+    description:
+      name: stream_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.8"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "1.0.4"
+  term_glyph:
+    dependency: transitive
+    description:
+      name: term_glyph
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+9"
+    version: "1.5.1"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   utf:
     dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+3"
+    version: "0.9.0+5"
+  vm_service_client:
+    dependency: transitive
+    description:
+      name: vm_service_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.6"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+4"
+    version: "0.9.7+10"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.9"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.13"
+    version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.17.0 <=2.0.0-dev.59.0"
+  dart: ">=2.1.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,14 @@
 name: dartsicord
 author: voximity <0zanfran@gmail.com>
 description: A Discord library for Dart
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/voximity/dartsicord
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  http:
-    git: https://github.com/dart-lang/http
+  http: '>=0.11.0 <=0.13.0'
 
 dev_dependencies:
-  test: ^0.12.0
+  test: ^1.0.0

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -52,7 +52,6 @@ void main() {
     expect(reactions.length, greaterThan(0));
   });*/
 
-	print("Tests are temporarily disabled while I figure out why they broke the test library");
-
-
+  print(
+      "Tests are temporarily disabled while I figure out why they broke the test library");
 }


### PR DESCRIPTION
- Disabled implicit casts in the analyzer to speed this up - it catches most of the cast failures due to json decoding earlier (you will not a lot more explicit casts now)
- Disabled the `as` lint because you basically have to use it with JSON (otherwise you create a ton of local variables just to avoid it)
- Changed http dependency to a real one as well and not a git dependency.
- The changes to http were abandoned and 0.12.0 was released instead. Those changes may be published as a new package not sure. Had to change a few apis but not a lot.
- Formatted with dartfmt (happens automatically for me... didn't want to disable it. If you disable whitespace diffs that should make it easier to review).
- Added generics where applicable to help out.
- Migrated the part statements to work via uri instead of library name which is a lot more reliable and explicit.
